### PR TITLE
Support non-x86_64 Architectures

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -22,10 +22,15 @@ get_platform() {
   uname | tr '[:upper:]' '[:lower:]'
 }
 
+get_arch() {
+  uname -m
+}
+
 get_installer_name() {
   local version="$1"
   local platform="$(get_platform)"
-  echo "bazel-$version-installer-$platform-x86_64.sh"
+  local arch="$(get_arch)"
+  echo "bazel-$version-installer-$platform-$arch.sh"
 }
 
 get_installer_url() {


### PR DESCRIPTION
Since the release of Bazel 4.1.0 there are additional supported architectures. Namely this enables Bazel installations on M1 (arm64) Mac architectures.