### PR TITLE
use .bazelversion to determine bazel version

### DIFF
--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+echo '.bazelversion'


### PR DESCRIPTION
bazel itself supports forcing a particular version of bazel to run with a .bazelversion file, but leaves the updating to bazelisk. this allows asdf-bazel to use the same file.