### PR TITLE
Fix Bazel installation for aarch64 architecture

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -27,7 +27,8 @@ get_arch() {
   # is not detected correctly within docker containers. See
   # https://github.com/moby/moby/issues/40141
   case "$(uname -m)" in \
-    "amd64")  BAZEL_ARCH=amd64 ;; \
+    "amd64")  BAZEL_ARCH=x86_64 ;; \
+    "x86_64")  BAZEL_ARCH=x86_64 ;; \
     "arm64")  BAZEL_ARCH=arm64  ;; \
     "aarch64")  BAZEL_ARCH=arm64  ;; \
     esac \

--- a/bin/install
+++ b/bin/install
@@ -26,18 +26,18 @@ get_arch() {
   dpkg --print-architecture
 }
 
-get_installer_name() {
+get_binary_name() {
   local version="$1"
   local platform="$(get_platform)"
   local arch="$(get_arch)"
-  echo "bazel-$version-installer-$platform-$arch.sh"
+  echo "bazel-$version-$platform-$arch"
 }
 
-get_installer_url() {
+get_binary_url() {
   local version="$1"
-  local installer_name="$(get_installer_name $version)"
+  local binary_name="$(get_binary_name $version)"
   local url_base="https://github.com/bazelbuild/bazel/releases/download"
-  echo "$url_base/$version/$installer_name"
+  echo "$url_base/$version/$binary_name"
 }
 
 check_install_type() {
@@ -57,16 +57,12 @@ install_bazel() {
   local version="$2"
   local install_path="$3"
   local tmpdir="$(get_tmpdir)"
-  local installer_name="$(get_installer_name $version)"
-  local installer_path="$tmpdir/$installer_name"
-  local installer_url="$(get_installer_url $version)"
+  local binary_url="$(get_binary_url $version)"
+  local install_filename="$install_path/bazel"
 
   check_install_type "$install_type"
 
-  curl -L -s -o "$installer_path" "$installer_url"
-  chmod u+x "$installer_path"
-
-  "$installer_path" --prefix="$install_path"
+  curl -L -s -o "$install_filename" "$binary_url"
 }
 
 install_bazel "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -58,11 +58,15 @@ install_bazel() {
   local install_path="$3"
   local tmpdir="$(get_tmpdir)"
   local binary_url="$(get_binary_url $version)"
-  local install_filename="$install_path/bazel"
+  local install_filename="$install_path/bin/bazel"
 
   check_install_type "$install_type"
 
-  curl -L -s -o "$install_filename" "$binary_url"
+  mkdir -p $(dirname "$install_filename")
+
+  curl -L -o "$install_filename" "$binary_url"
+
+  chmod u+x "$install_filename"
 }
 
 install_bazel "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -23,7 +23,15 @@ get_platform() {
 }
 
 get_arch() {
-  uname -m
+  # NOTE: have to use this switch statement because the platform
+  # is not detected correctly within docker containers. See
+  # https://github.com/moby/moby/issues/40141
+  case "$(uname -m)" in \
+    "amd64")  BAZEL_ARCH=amd64 ;; \
+    "arm64")  BAZEL_ARCH=arm64  ;; \
+    "aarch64")  BAZEL_ARCH=arm64  ;; \
+    esac \
+    && echo $BAZEL_ARCH
 }
 
 get_binary_name() {

--- a/bin/install
+++ b/bin/install
@@ -23,7 +23,7 @@ get_platform() {
 }
 
 get_arch() {
-  uname -m
+  dpkg --print-architecture
 }
 
 get_installer_name() {

--- a/bin/install
+++ b/bin/install
@@ -23,7 +23,7 @@ get_platform() {
 }
 
 get_arch() {
-  dpkg --print-architecture
+  uname -m
 }
 
 get_binary_name() {


### PR DESCRIPTION
closes #6 

Because there is no installer available for the arm64 linux version I've updated the installer to work directly with the Bazel binary.